### PR TITLE
Change license to that used by PS documentation project

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,13 @@
+This file lists the contributors to the purescript-documentation-discussion project, and that they have licensed their contributions to the owners and users of the project.
+
+## Contributors
+
+Contributors listed here agree to license their contributions under the following terms:
+
+> My existing contributions and all future contributions until further notice are Copyright {Name}, and are licensed to the owners and users of the purescript-documentation-discussion project under the terms of the [CC BY-NC-SA 4.0](https://creativecommons.org/licenses/by-nc-sa/4.0/deed) license.
+
+By adding your name to the list below, you agree to license your contributions under the above terms.
+
+| Username | Name |
+| :------- | :--- |
+| [@chexxor](https://github.com/chexxor) | Alex Berg |

--- a/LICENSE
+++ b/LICENSE
@@ -1,9 +1,0 @@
-purescript-documentation-discussion (c) 2019 by chexxor
-
-purescript-documentation-discussion is licensed under a
-Creative Commons Attribution-NonCommercial-ShareAlike 4.0 Unported License.
-
-The contents of this license apply to original productions of this project and its interpretations of other works, not the works it cites.
-
-You should have received a copy of the license along with this
-work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>

--- a/LICENSE
+++ b/LICENSE
@@ -1,21 +1,9 @@
-MIT License
+purescript-documentation-discussion (c) 2019 by chexxor
 
-Copyright (c) 2019 Alex Berg
+purescript-documentation-discussion is licensed under a
+Creative Commons Attribution-NonCommercial-ShareAlike 4.0 Unported License.
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+The contents of this license apply to original productions of this project and its interpretations of other works, not the works it cites.
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
-
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+You should have received a copy of the license along with this
+work.  If not, see <http://creativecommons.org/licenses/by-nc-sa/4.0/>

--- a/README.md
+++ b/README.md
@@ -38,3 +38,7 @@ Once you have finished your initial work...
 1. Move the file to the corresponding "For [other person]" folder to indicate that this person can review your work.
 2. Push this final change to `master`
 3. Mark the corresponding issue as closed with a comment that includes the specific commit hash that has the final commit in your work.
+
+## License
+
+See the [CONTRIBUTORS.md](CONTRIBUTORS.md) file for license.


### PR DESCRIPTION
Change the license to that used in the PureScript/documentation project.

As discussed in https://github.com/chexxor/purescript-documentation-discussion/issues/23